### PR TITLE
Issue #66 is complete

### DIFF
--- a/project3/components/CalendarDisplayer.js
+++ b/project3/components/CalendarDisplayer.js
@@ -3,12 +3,14 @@ import { AsyncStorage, StyleSheet, Text, View, List, TouchableOpacity, Modal, Im
 import { Calendar, CalendarList, Agenda } from 'react-native-calendars';
 import styles from "../stylesheets/Calendar.style.js";
 import DatePicker from 'react-native-datepicker';
+import Moment from 'moment';
 
 export default class CalendarDisplayer extends React.Component {
     constructor(props) {
       super(props);
+      let date = Moment().format("YYYY-MM-DD");
       this.state = {
-        date: "",
+        date: date,
         startTime: "",
         endTime: "",
         eventDate: "",
@@ -101,7 +103,7 @@ export default class CalendarDisplayer extends React.Component {
                     transparent={false}
                     visible={this.state.modalVisible}
                     //If the back button on the users phone is pressed, close the Modal
-                    onRequestClose={()=>{this.setModalVisible(!this.state.modalVisible);}}>
+                    onRequestClose={()=>{this.closeModal();}}>
                   <View style={styles.modalView}>
                     <View style={styles.modal}>
                         {/*Simple backbutton if the user choose to not do any changes*/}
@@ -120,6 +122,7 @@ export default class CalendarDisplayer extends React.Component {
                             onChangeText={(text) => this.setState({eventText : text})}
                             placeholder={"Event description"}
                             value={this.state.eventText}
+                            multiline={true}
                         />
 
                         <View style={styles.modalItem}>
@@ -142,7 +145,7 @@ export default class CalendarDisplayer extends React.Component {
                                 mode="time"
                                 placeholder="start time"
                                 is24Hour={true}
-                                format="LT"
+                                format={('HH:MM')}
                                 iconSource={require('../assets/clock.png')}
                                 confirmBtnText="Confirm"
                                 cancelBtnText="Cancel"
@@ -157,7 +160,7 @@ export default class CalendarDisplayer extends React.Component {
                                 mode="time"
                                 placeholder="end time"
                                 is24Hour={true}
-                                format="LT"
+                                format={('HH:MM')}
                                 iconSource={require('../assets/clock.png')}
                                 confirmBtnText="Confirm"
                                 cancelBtnText="Cancel"
@@ -285,7 +288,7 @@ export default class CalendarDisplayer extends React.Component {
           if(this.state.items[newDate].length>0){
             //Check if date has an object where name value is "No upcoming events."
             //If so, this must be deleted in order for it not to show in calendar
-            if(this.state.items[newDate][0]["name"]=="No upcoming events."){
+            if(this.state.items[newDate][0]["name"]=="No upcoming events." || this.state.items[newDate][0]["name"]=="No events to show." ){
               //Delete event that says "no upcoming event"
               delete this.state.items[newDate];
               //Create new, empty date key in object

--- a/project3/stylesheets/Calendar.style.js
+++ b/project3/stylesheets/Calendar.style.js
@@ -105,12 +105,11 @@ export default StyleSheet.create({
     modalClose: {
         alignSelf: "flex-start",
         marginLeft: 10,
-        marginBottom: 25,
         position: "absolute",
         top: -10,
         left: -10,
         backgroundColor: "#5cacec",
-        height: "20%",
+        height: "15%",
         width: 50,
         alignItems: "center",
         justifyContent: "center",
@@ -144,11 +143,13 @@ export default StyleSheet.create({
     },
 
     textInput: {
-        width: "100%",
+        width: "90%",
+        marginTop: "3%",
         fontSize: 25,
         textAlign: "center",
         backgroundColor: "#ededed",
         padding: 20,
+        borderWidth: 1,
     },
 
     newEventTitle: {

--- a/project3/stylesheets/ListItem.style.js
+++ b/project3/stylesheets/ListItem.style.js
@@ -137,7 +137,9 @@ export default StyleSheet.create({
     },
 
     modalText: {
-        width: "100%",
+        width: "90%",
+        marginTop: "3%",
+        borderWidth: 1,
         fontSize: 25,
         textAlign: "center",
         backgroundColor: "#ededed",


### PR DESCRIPTION
- [x] In Calendar, reset states when onRequestClose is called.
- [x] In both Modals, the text input should have a box around it to make it look like an input field.
- [x] In Calendar, times should be saved in a 24 hour format.
- [x] If there are no events, and you add one, the "No events to show" should be deleted.